### PR TITLE
JWT 인증 & 회원가입 및 로그인 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
     implementation("net.logstash.logback:logstash-logback-encoder:8.0")
+
+
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 
     implementation 'org.projectlombok:lombok'
     annotationProcessor("org.projectlombok:lombok")

--- a/https/auth.http
+++ b/https/auth.http
@@ -1,0 +1,67 @@
+### 회원가입
+POST http://localhost:8080/auth/register
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "password": "Test1234!",
+  "name": "홍길동",
+  "role": "LEARNER",
+  "tagIds": [1, 2, 3],
+  "level": "JUNIOR"
+}
+
+### 회원가입 - 이메일 중복 (409)
+POST http://localhost:8080/auth/register
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "password": "Test1234!",
+  "name": "홍길동",
+  "role": "LEARNER",
+  "tagIds": [1, 2, 3],
+  "level": "JUNIOR"
+}
+
+### 회원가입 - 비밀번호 정규식 미충족 (400)
+POST http://localhost:8080/auth/register
+Content-Type: application/json
+
+{
+  "email": "test2@example.com",
+  "password": "weak",
+  "name": "홍길동",
+  "role": "LEARNER",
+  "tagIds": [1],
+  "level": "JUNIOR"
+}
+
+### 로그인
+POST http://localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "password": "Test1234!"
+}
+
+### 로그인 - 잘못된 비밀번호 (401)
+POST http://localhost:8080/auth/login
+Content-Type: application/json
+
+{
+  "email": "test@example.com",
+  "password": "WrongPass1!"
+}
+
+### 인증 필요 API - 토큰 없이 (401)
+GET http://localhost:8080/users/me
+
+### 인증 필요 API - 유효하지 않은 토큰 (401 AUTH-004)
+GET http://localhost:8080/users/me
+Authorization: Bearer invalid.token.here
+
+### 인증 필요 API - 만료된 토큰 (401 AUTH-004)
+GET http://localhost:8080/users/me
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZXMiOlsiTEVBUk5FUiJdLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTcwMDAwMDAwMX0.expired

--- a/https/auth.http
+++ b/https/auth.http
@@ -58,10 +58,6 @@ Content-Type: application/json
 ### 인증 필요 API - 토큰 없이 (401)
 GET http://localhost:8080/users/me
 
-### 인증 필요 API - 유효하지 않은 토큰 (401 AUTH-004)
+### 인증 필요 API - 유효하지 않은 토큰 (401)
 GET http://localhost:8080/users/me
 Authorization: Bearer invalid.token.here
-
-### 인증 필요 API - 만료된 토큰 (401 AUTH-004)
-GET http://localhost:8080/users/me
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIiwicm9sZXMiOlsiTEVBUk5FUiJdLCJpYXQiOjE3MDAwMDAwMDAsImV4cCI6MTcwMDAwMDAwMX0.expired

--- a/src/main/java/com/lxpbe/auth/application/dto/LoginDto.java
+++ b/src/main/java/com/lxpbe/auth/application/dto/LoginDto.java
@@ -1,0 +1,13 @@
+package com.lxpbe.auth.application.dto;
+
+import com.lxpbe.auth.presentation.request.LoginRequest;
+
+public record LoginDto(
+        String email,
+        String password
+) {
+
+    public static LoginDto from(LoginRequest request) {
+        return new LoginDto(request.email(), request.password());
+    }
+}

--- a/src/main/java/com/lxpbe/auth/application/dto/RegisterDto.java
+++ b/src/main/java/com/lxpbe/auth/application/dto/RegisterDto.java
@@ -1,0 +1,27 @@
+package com.lxpbe.auth.application.dto;
+
+import com.lxpbe.auth.presentation.request.RegisterRequest;
+import com.lxpbe.user.domain.enums.Level;
+import com.lxpbe.user.domain.enums.Role;
+import java.util.List;
+
+public record RegisterDto(
+        String email,
+        String password,
+        String name,
+        Role role,
+        List<Long> tagIds,
+        Level level
+) {
+
+    public static RegisterDto from(RegisterRequest request) {
+        return new RegisterDto(
+                request.email(),
+                request.password(),
+                request.name(),
+                request.role(),
+                request.tagIds(),
+                request.level()
+        );
+    }
+}

--- a/src/main/java/com/lxpbe/auth/application/service/AuthService.java
+++ b/src/main/java/com/lxpbe/auth/application/service/AuthService.java
@@ -1,0 +1,57 @@
+package com.lxpbe.auth.application.service;
+
+import com.lxpbe.auth.application.dto.LoginDto;
+import com.lxpbe.auth.application.dto.RegisterDto;
+import com.lxpbe.auth.domain.exception.AuthErrorCode;
+import com.lxpbe.auth.presentation.response.TokenResponse;
+import com.lxpbe.common.exception.DomainException;
+import com.lxpbe.common.security.JwtTokenProvider;
+import com.lxpbe.user.domain.User;
+import com.lxpbe.user.infrastructure.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Transactional
+    public void register(RegisterDto dto) {
+        validateDuplicateEmail(dto.email());
+
+        User user = User.create(
+                dto.email(),
+                passwordEncoder.encode(dto.password()),
+                dto.name(),
+                dto.role(),
+                dto.level(),
+                dto.tagIds()
+        );
+
+        userRepository.save(user);
+    }
+
+    @Transactional
+    public TokenResponse login(LoginDto dto) {
+        User user = userRepository.findByEmail(dto.email())
+                .orElseThrow(() -> new DomainException(AuthErrorCode.LOGIN_FAILED));
+
+        if (!passwordEncoder.matches(dto.password(), user.getPassword())) {
+            throw new DomainException(AuthErrorCode.LOGIN_FAILED);
+        }
+
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getRoles());
+        return new TokenResponse(accessToken);
+    }
+
+    private void validateDuplicateEmail(String email) {
+        if (userRepository.existsByEmail(email)) {
+            throw new DomainException(AuthErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+}

--- a/src/main/java/com/lxpbe/auth/application/service/AuthService.java
+++ b/src/main/java/com/lxpbe/auth/application/service/AuthService.java
@@ -7,6 +7,7 @@ import com.lxpbe.auth.presentation.response.TokenResponse;
 import com.lxpbe.common.exception.DomainException;
 import com.lxpbe.common.security.JwtTokenProvider;
 import com.lxpbe.user.domain.User;
+import com.lxpbe.user.domain.exception.UserErrorCode;
 import com.lxpbe.user.infrastructure.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -51,7 +52,7 @@ public class AuthService {
 
     private void validateDuplicateEmail(String email) {
         if (userRepository.existsByEmail(email)) {
-            throw new DomainException(AuthErrorCode.DUPLICATE_EMAIL);
+            throw new DomainException(UserErrorCode.DUPLICATE_EMAIL);
         }
     }
 }

--- a/src/main/java/com/lxpbe/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/lxpbe/auth/domain/exception/AuthErrorCode.java
@@ -8,9 +8,7 @@ import java.util.Objects;
 public enum AuthErrorCode implements ErrorCode {
 
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-001", "이메일 형식이 올바르지 않습니다."),
-
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH-002", "이메일이 중복됩니다."),
-
     LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-003", "이메일이나 비밀번호가 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-004", "토큰이 유효하지 않습니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-005", "만료된 토큰입니다."),

--- a/src/main/java/com/lxpbe/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/lxpbe/auth/domain/exception/AuthErrorCode.java
@@ -7,11 +7,9 @@ import java.util.Objects;
 
 public enum AuthErrorCode implements ErrorCode {
 
-    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-001", "이메일 형식이 올바르지 않습니다."),
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH-002", "이메일이 중복됩니다."),
-    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-003", "이메일이나 비밀번호가 일치하지 않습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-004", "토큰이 유효하지 않습니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-005", "만료된 토큰입니다."),
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-001", "이메일이나 비밀번호가 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-002", "토큰이 유효하지 않습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-003", "만료된 토큰입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/lxpbe/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/lxpbe/auth/domain/exception/AuthErrorCode.java
@@ -1,0 +1,44 @@
+package com.lxpbe.auth.domain.exception;
+
+import com.lxpbe.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.util.Objects;
+
+public enum AuthErrorCode implements ErrorCode {
+
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "AUTH-001", "이메일 형식이 올바르지 않습니다."),
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "AUTH-002", "이메일이 중복됩니다."),
+
+    LOGIN_FAILED(HttpStatus.UNAUTHORIZED, "AUTH-003", "이메일이나 비밀번호가 일치하지 않습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-004", "토큰이 유효하지 않습니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH-005", "만료된 토큰입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(HttpStatus httpStatus, String code, String message) {
+        Objects.requireNonNull(httpStatus, "AuthErrorCode.httpStatus 는 null 일 수 없습니다.");
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/com/lxpbe/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/lxpbe/auth/presentation/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.lxpbe.auth.presentation.request.LoginRequest;
 import com.lxpbe.auth.presentation.request.RegisterRequest;
 import com.lxpbe.auth.presentation.response.TokenResponse;
 import com.lxpbe.common.response.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,13 +23,13 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/register")
-    public ResponseEntity<Void> register(@RequestBody RegisterRequest request) {
+    public ResponseEntity<Void> register(@Valid @RequestBody RegisterRequest request) {
         authService.register(RegisterDto.from(request));
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenResponse>> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
         TokenResponse tokenResponse = authService.login(LoginDto.from(request));
         return ResponseEntity.ok(new ApiResponse<>(tokenResponse, null));
     }

--- a/src/main/java/com/lxpbe/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/lxpbe/auth/presentation/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.lxpbe.auth.presentation.controller;
+
+import com.lxpbe.auth.application.dto.LoginDto;
+import com.lxpbe.auth.application.dto.RegisterDto;
+import com.lxpbe.auth.application.service.AuthService;
+import com.lxpbe.auth.presentation.request.LoginRequest;
+import com.lxpbe.auth.presentation.request.RegisterRequest;
+import com.lxpbe.auth.presentation.response.TokenResponse;
+import com.lxpbe.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+
+    @PostMapping("/register")
+    public ResponseEntity<Void> register(@RequestBody RegisterRequest request) {
+        authService.register(RegisterDto.from(request));
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<TokenResponse>> login(@RequestBody LoginRequest request) {
+        TokenResponse tokenResponse = authService.login(LoginDto.from(request));
+        return ResponseEntity.ok(new ApiResponse<>(tokenResponse, null));
+    }
+}

--- a/src/main/java/com/lxpbe/auth/presentation/request/LoginRequest.java
+++ b/src/main/java/com/lxpbe/auth/presentation/request/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.lxpbe.auth.presentation.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record LoginRequest(
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 비어있을 수 없습니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 비어있을 수 없습니다.")
+        @Pattern(regexp = PASSWORD_REGEX,
+                message = "비밀번호는 영어 대/소문자, 숫자, 특수문자를 각각 1개 이상 포함하여 8~20자여야 합니다.")
+        String password
+) {
+    private static final String PASSWORD_REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$";
+}

--- a/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
+++ b/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 
 public record RegisterRequest(
@@ -21,6 +22,7 @@ public record RegisterRequest(
         @NotNull(message = "역할은 비어있을 수 없습니다.")
         Role role,
         @NotNull(message = "태그는 비어있을 수 없습니다.")
+        @Size(min = 3, max = 5, message = "태그는 3개 이상 5개 이하로 입력해야 합니다.")
         List<Long> tagIds,
         @NotNull(message = "레벨은 비어있을 수 없습니다.")
         Level level

--- a/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
+++ b/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
@@ -4,6 +4,7 @@ import com.lxpbe.user.domain.enums.Level;
 import com.lxpbe.user.domain.enums.Role;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import java.util.List;
 
@@ -17,11 +18,11 @@ public record RegisterRequest(
         String password,
         @NotBlank(message = "이름은 비어있을 수 없습니다.")
         String name,
-        @NotBlank(message = "역할은 비어있을 수 없습니다.")
+        @NotNull(message = "역할은 비어있을 수 없습니다.")
         Role role,
-        @NotBlank(message = "태그는 비어있을 수 없습니다.")
+        @NotNull(message = "태그는 비어있을 수 없습니다.")
         List<Long> tagIds,
-        @NotBlank(message = "레벨은 비어있을 수 없습니다.")
+        @NotNull(message = "레벨은 비어있을 수 없습니다.")
         Level level
 ) {
     private static final String PASSWORD_REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$";

--- a/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
+++ b/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
@@ -1,0 +1,27 @@
+package com.lxpbe.auth.presentation.request;
+
+import com.lxpbe.user.domain.enums.Level;
+import com.lxpbe.user.domain.enums.Role;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import java.util.List;
+
+public record RegisterRequest(
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @NotBlank(message = "이메일은 비어있을 수 없습니다.")
+        String email,
+        @NotBlank(message = "비밀번호는 비어있을 수 없습니다.")
+        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$",
+                message = "비밀번호는 영어 대/소문자, 숫자, 특수문자를 각각 1개 이상 포함하여 8~20자여야 합니다.")
+        String password,
+        @NotBlank(message = "이름은 비어있을 수 없습니다.")
+        String name,
+        @NotBlank(message = "역할은 비어있을 수 없습니다.")
+        Role role,
+        @NotBlank(message = "태그는 비어있을 수 없습니다.")
+        List<Long> tagIds,
+        @NotBlank(message = "레벨은 비어있을 수 없습니다.")
+        Level level
+) {
+}

--- a/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
+++ b/src/main/java/com/lxpbe/auth/presentation/request/RegisterRequest.java
@@ -12,7 +12,7 @@ public record RegisterRequest(
         @NotBlank(message = "이메일은 비어있을 수 없습니다.")
         String email,
         @NotBlank(message = "비밀번호는 비어있을 수 없습니다.")
-        @Pattern(regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$",
+        @Pattern(regexp = PASSWORD_REGEX,
                 message = "비밀번호는 영어 대/소문자, 숫자, 특수문자를 각각 1개 이상 포함하여 8~20자여야 합니다.")
         String password,
         @NotBlank(message = "이름은 비어있을 수 없습니다.")
@@ -24,4 +24,5 @@ public record RegisterRequest(
         @NotBlank(message = "레벨은 비어있을 수 없습니다.")
         Level level
 ) {
+    private static final String PASSWORD_REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,20}$";
 }

--- a/src/main/java/com/lxpbe/auth/presentation/response/TokenResponse.java
+++ b/src/main/java/com/lxpbe/auth/presentation/response/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.lxpbe.auth.presentation.response;
+
+public record TokenResponse(
+        String accessToken
+) {
+}

--- a/src/main/java/com/lxpbe/common/config/JpaAuditingConfig.java
+++ b/src/main/java/com/lxpbe/common/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.lxpbe.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/lxpbe/common/config/SecurityConfig.java
+++ b/src/main/java/com/lxpbe/common/config/SecurityConfig.java
@@ -31,8 +31,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
-                                "/users/register",
-                                "/users/login"
+                                "/auth/register",
+                                "/auth/login"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/lxpbe/common/config/SecurityConfig.java
+++ b/src/main/java/com/lxpbe/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.lxpbe.common.config;
 
+import com.lxpbe.common.security.JwtAuthenticationEntryPoint;
 import com.lxpbe.common.security.JwtAuthenticationFilter;
 import com.lxpbe.common.security.JwtProperties;
 import com.lxpbe.common.security.JwtTokenProvider;
@@ -22,6 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -35,6 +37,9 @@ public class SecurityConfig {
                                 "/auth/login"
                         ).permitAll()
                         .anyRequest().authenticated()
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .build();

--- a/src/main/java/com/lxpbe/common/config/SecurityConfig.java
+++ b/src/main/java/com/lxpbe/common/config/SecurityConfig.java
@@ -1,0 +1,47 @@
+package com.lxpbe.common.config;
+
+import com.lxpbe.common.security.JwtAuthenticationFilter;
+import com.lxpbe.common.security.JwtProperties;
+import com.lxpbe.common.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableConfigurationProperties(JwtProperties.class)
+@RequiredArgsConstructor
+public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .cors(cors -> {})
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/users/register",
+                                "/users/login"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/lxpbe/common/config/WebConfig.java
+++ b/src/main/java/com/lxpbe/common/config/WebConfig.java
@@ -10,7 +10,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins(
+                        "http://localhost:3000",
+                        "http://1.213.216.100:3000"
+                )
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);

--- a/src/main/java/com/lxpbe/common/config/WebConfig.java
+++ b/src/main/java/com/lxpbe/common/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.lxpbe.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("*")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/lxpbe/common/domain/BaseEntity.java
+++ b/src/main/java/com/lxpbe/common/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.lxpbe.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/lxpbe/common/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/lxpbe/common/security/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,41 @@
+package com.lxpbe.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.lxpbe.auth.domain.exception.AuthErrorCode;
+import com.lxpbe.common.exception.ErrorBody;
+import com.lxpbe.common.exception.ErrorCode;
+import com.lxpbe.common.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        ErrorCode errorCode = (ErrorCode) request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_ATTRIBUTE);
+
+        if (errorCode == null) {
+            errorCode = AuthErrorCode.INVALID_TOKEN;
+        }
+
+        response.setStatus(errorCode.httpStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        ErrorBody errorBody = new ErrorBody(errorCode.code(), errorCode.message());
+        ApiResponse<Void> body = new ApiResponse<>(null, errorBody);
+        objectMapper.writeValue(response.getWriter(), body);
+    }
+}

--- a/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package com.lxpbe.common.security;
 
+import com.lxpbe.common.exception.DomainException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -17,6 +18,7 @@ import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    public static final String AUTH_ERROR_ATTRIBUTE = "AUTH_ERROR";
     private static final String AUTHORIZATION_HEADER = "Authorization";
     private static final String BEARER_PREFIX = "Bearer ";
     private static final String ROLE_PREFIX = "ROLE_";
@@ -29,18 +31,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         String token = extractToken(request);
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
-            Claims claims = jwtTokenProvider.getClaimsFromToken(token);
-            Long userId = Long.valueOf(claims.getSubject());
+        if (token != null) {
+            try {
+                Claims claims = jwtTokenProvider.getClaimsFromToken(token);
+                Long userId = Long.valueOf(claims.getSubject());
 
-            List<String> roles = claims.get("roles", List.class);
-            List<SimpleGrantedAuthority> authorities = roles.stream()
-                    .map(role -> new SimpleGrantedAuthority(ROLE_PREFIX + role))
-                    .toList();
+                List<String> roles = claims.get("roles", List.class);
+                List<SimpleGrantedAuthority> authorities = roles.stream()
+                        .map(role -> new SimpleGrantedAuthority(ROLE_PREFIX + role))
+                        .toList();
 
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(userId, null, authorities);
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(userId, null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (DomainException e) {
+                request.setAttribute(AUTH_ERROR_ATTRIBUTE, e.errorCode());
+            }
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
@@ -1,0 +1,56 @@
+package com.lxpbe.common.security;
+
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String ROLE_PREFIX = "ROLE_";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        String token = extractToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Claims claims = jwtTokenProvider.getClaimsFromToken(token);
+            Long userId = Long.valueOf(claims.getSubject());
+
+            List<String> roles = claims.get("roles", List.class);
+            List<SimpleGrantedAuthority> authorities = roles.stream()
+                    .map(role -> new SimpleGrantedAuthority(ROLE_PREFIX + role))
+                    .toList();
+
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userId, null, authorities);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractToken(HttpServletRequest request) {
+        String header = request.getHeader(AUTHORIZATION_HEADER);
+        if (header != null && header.startsWith(BEARER_PREFIX)) {
+            return header.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/lxpbe/common/security/JwtProperties.java
+++ b/src/main/java/com/lxpbe/common/security/JwtProperties.java
@@ -1,0 +1,10 @@
+package com.lxpbe.common.security;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long accessTokenExpiration
+) {
+}

--- a/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
@@ -1,0 +1,61 @@
+package com.lxpbe.common.security;
+
+import com.lxpbe.user.domain.Role;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Set;
+
+@Component
+public class JwtTokenProvider {
+    private final SecretKey secretKey;
+    private final long accessTokenExpiration;
+
+    public JwtTokenProvider(JwtProperties jwtProperties) {
+        this.secretKey = Keys.hmacShaKeyFor(
+                jwtProperties.secret()
+                        .getBytes(StandardCharsets.UTF_8)
+        );
+        this.accessTokenExpiration = jwtProperties.accessTokenExpiration();
+    }
+
+    public String generateAccessToken(Long userId, Set<Role> roles) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("roles", roles.stream().map(Enum::name).toList())
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            getClaimsFromToken(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public Long getUserIdFromToken(String token) {
+        return Long.valueOf(getClaimsFromToken(token).getSubject());
+    }
+
+    public Claims getClaimsFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
@@ -1,7 +1,10 @@
 package com.lxpbe.common.security;
 
+import com.lxpbe.auth.domain.exception.AuthErrorCode;
+import com.lxpbe.common.exception.DomainException;
 import com.lxpbe.user.domain.enums.Role;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -38,24 +41,17 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public boolean validateToken(String token) {
-        try {
-            getClaimsFromToken(token);
-            return true;
-        } catch (JwtException | IllegalArgumentException e) {
-            return false;
-        }
-    }
-
-    public Long getUserIdFromToken(String token) {
-        return Long.valueOf(getClaimsFromToken(token).getSubject());
-    }
-
     public Claims getClaimsFromToken(String token) {
-        return Jwts.parser()
-                .verifyWith(secretKey)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload();
+        try {
+            return Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+        } catch (ExpiredJwtException e) {
+            throw new DomainException(AuthErrorCode.EXPIRED_TOKEN, e);
+        } catch (JwtException | IllegalArgumentException e) {
+            throw new DomainException(AuthErrorCode.INVALID_TOKEN, e);
+        }
     }
 }

--- a/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
@@ -1,6 +1,6 @@
 package com.lxpbe.common.security;
 
-import com.lxpbe.user.domain.Role;
+import com.lxpbe.user.domain.enums.Role;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;

--- a/src/main/java/com/lxpbe/user/domain/Level.java
+++ b/src/main/java/com/lxpbe/user/domain/Level.java
@@ -1,0 +1,19 @@
+package com.lxpbe.user.domain;
+
+import lombok.Getter;
+
+public enum Level {
+
+    JUNIOR("주니어"),
+    MIDDLE("미들"),
+    SENIOR("시니어"),
+    EXPERT("익스퍼트")
+    ;
+
+    @Getter
+    private final String description;
+
+    Level(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/lxpbe/user/domain/Role.java
+++ b/src/main/java/com/lxpbe/user/domain/Role.java
@@ -1,0 +1,18 @@
+package com.lxpbe.user.domain;
+
+import lombok.Getter;
+
+public enum Role {
+    LEARNER("학습자"),
+    INSTRUCTOR("강사"),
+    ADMIN("관리자")
+    ;
+
+    @Getter
+    private final String description;
+
+    Role(String description) {
+        this.description = description;
+    }
+}
+

--- a/src/main/java/com/lxpbe/user/domain/User.java
+++ b/src/main/java/com/lxpbe/user/domain/User.java
@@ -1,6 +1,8 @@
 package com.lxpbe.user.domain;
 
+import com.lxpbe.auth.domain.exception.AuthErrorCode;
 import com.lxpbe.common.domain.BaseEntity;
+import com.lxpbe.common.exception.DomainException;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -19,6 +21,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,6 +31,9 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
+
+    private static final Pattern EMAIL_PATTERN =
+            Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
 
     @Id @Getter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -75,6 +81,7 @@ public class User extends BaseEntity {
 
     public static User create(String email, String encodedPassword, String name,
                                Role role, Level level, List<Long> tagIds) {
+        validateEmailRegex(email);
         return User.builder()
                 .email(email)
                 .password(encodedPassword)
@@ -83,5 +90,11 @@ public class User extends BaseEntity {
                 .level(level)
                 .tagIds(tagIds)
                 .build();
+    }
+
+    private static void validateEmailRegex( String email) {
+        if (!EMAIL_PATTERN.matcher(email).matches()) {
+            throw new DomainException(AuthErrorCode.INVALID_EMAIL_FORMAT);
+        }
     }
 }

--- a/src/main/java/com/lxpbe/user/domain/User.java
+++ b/src/main/java/com/lxpbe/user/domain/User.java
@@ -1,0 +1,73 @@
+package com.lxpbe.user.domain;
+
+import com.lxpbe.common.domain.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "users")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id @Getter
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Getter
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Getter
+    @Column(nullable = false)
+    private String password;
+
+    @Getter
+    @Column(nullable = false)
+    private String name;
+
+    @Getter
+    @Column(name = "role")
+    @Enumerated(EnumType.STRING)
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
+    private Set<Role> roles = EnumSet.noneOf(Role.class);
+
+    @Getter
+    @Enumerated(EnumType.STRING)
+    private Level level;
+
+    @Getter
+    @Column(name = "tag_id")
+    @ElementCollection
+    @CollectionTable(name = "user_tags", joinColumns = @JoinColumn(name = "user_id"))
+    private List<Long> tagIds = new ArrayList<>();
+
+    @Builder
+    private User(String email, String password, String name,
+                 Set<Role> roles, Level level, List<Long> tagIds) {
+        this.email = email;
+        this.password = password;
+        this.name = name;
+        this.roles = roles != null ? roles : EnumSet.noneOf(Role.class);
+        this.level = level;
+        this.tagIds = tagIds != null ? tagIds : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/lxpbe/user/domain/User.java
+++ b/src/main/java/com/lxpbe/user/domain/User.java
@@ -1,8 +1,8 @@
 package com.lxpbe.user.domain;
 
-import com.lxpbe.auth.domain.exception.AuthErrorCode;
 import com.lxpbe.common.domain.BaseEntity;
 import com.lxpbe.common.exception.DomainException;
+import com.lxpbe.user.domain.exception.UserErrorCode;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
@@ -34,6 +34,8 @@ public class User extends BaseEntity {
 
     private static final Pattern EMAIL_PATTERN =
             Pattern.compile("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+    private static final int MIN_TAG_COUNT = 3;
+    private static final int MAX_TAG_COUNT = 5;
 
     @Id @Getter
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -82,6 +84,7 @@ public class User extends BaseEntity {
     public static User create(String email, String encodedPassword, String name,
                                Role role, Level level, List<Long> tagIds) {
         validateEmailRegex(email);
+        validateCountTagIds(tagIds);
         return User.builder()
                 .email(email)
                 .password(encodedPassword)
@@ -92,9 +95,15 @@ public class User extends BaseEntity {
                 .build();
     }
 
-    private static void validateEmailRegex( String email) {
+    private static void validateEmailRegex(String email) {
         if (!EMAIL_PATTERN.matcher(email).matches()) {
-            throw new DomainException(AuthErrorCode.INVALID_EMAIL_FORMAT);
+            throw new DomainException(UserErrorCode.INVALID_EMAIL_FORMAT);
+        }
+    }
+
+    private static void validateCountTagIds(List<Long> tagIds) {
+        if (tagIds.size() < MIN_TAG_COUNT || tagIds.size() > MAX_TAG_COUNT) {
+            throw new DomainException(UserErrorCode.INVALID_TAG_COUNT);
         }
     }
 }

--- a/src/main/java/com/lxpbe/user/domain/User.java
+++ b/src/main/java/com/lxpbe/user/domain/User.java
@@ -13,6 +13,8 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Table;
+import com.lxpbe.user.domain.enums.Level;
+import com.lxpbe.user.domain.enums.Role;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -69,5 +71,17 @@ public class User extends BaseEntity {
         this.roles = roles != null ? roles : EnumSet.noneOf(Role.class);
         this.level = level;
         this.tagIds = tagIds != null ? tagIds : new ArrayList<>();
+    }
+
+    public static User create(String email, String encodedPassword, String name,
+                               Role role, Level level, List<Long> tagIds) {
+        return User.builder()
+                .email(email)
+                .password(encodedPassword)
+                .name(name)
+                .roles(EnumSet.of(role))
+                .level(level)
+                .tagIds(tagIds)
+                .build();
     }
 }

--- a/src/main/java/com/lxpbe/user/domain/enums/Level.java
+++ b/src/main/java/com/lxpbe/user/domain/enums/Level.java
@@ -1,4 +1,4 @@
-package com.lxpbe.user.domain;
+package com.lxpbe.user.domain.enums;
 
 import lombok.Getter;
 

--- a/src/main/java/com/lxpbe/user/domain/enums/Role.java
+++ b/src/main/java/com/lxpbe/user/domain/enums/Role.java
@@ -5,7 +5,8 @@ import lombok.Getter;
 public enum Role {
     LEARNER("학습자"),
     INSTRUCTOR("강사"),
-    ADMIN("관리자")
+    ADMIN("관리자"),
+    CS_MANAGER("CS 담당자")
     ;
 
     @Getter

--- a/src/main/java/com/lxpbe/user/domain/enums/Role.java
+++ b/src/main/java/com/lxpbe/user/domain/enums/Role.java
@@ -1,4 +1,4 @@
-package com.lxpbe.user.domain;
+package com.lxpbe.user.domain.enums;
 
 import lombok.Getter;
 
@@ -15,4 +15,3 @@ public enum Role {
         this.description = description;
     }
 }
-

--- a/src/main/java/com/lxpbe/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/lxpbe/user/domain/exception/UserErrorCode.java
@@ -1,0 +1,41 @@
+package com.lxpbe.user.domain.exception;
+
+import com.lxpbe.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+import java.util.Objects;
+
+public enum UserErrorCode implements ErrorCode {
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "USR-001", "이메일이 중복됩니다."),
+    INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "USR-002", "이메일 형식이 올바르지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USR-003", "사용자를 찾을 수 없습니다."),
+    INVALID_TAG_COUNT(HttpStatus.BAD_REQUEST, "USR-004", "태그는 최소 3개, 최대 5개여야 합니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    UserErrorCode(HttpStatus httpStatus, String code, String message) {
+        Objects.requireNonNull(httpStatus, "UserErrorCode.httpStatus 는 null 일 수 없습니다.");
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/com/lxpbe/user/infrastructure/repository/UserRepository.java
+++ b/src/main/java/com/lxpbe/user/infrastructure/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.lxpbe.user.infrastructure.repository;
+
+import com.lxpbe.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,6 +18,10 @@ spring:
         use_sql_comments: true
     database-platform: org.hibernate.dialect.MySQLDialect
 
+jwt:
+  secret: ${JWT_SECRET_KEY}
+  accessToken-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,7 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET_KEY}
-  accessToken-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION}
+  access-token-expiration: ${JWT_TOKEN_EXPIRATION:3600000}
 
 logging:
   level:


### PR DESCRIPTION
> Issue closed : #10 

## Summary                                                                                          
                                                                                                                                                                                                                                      
  - JWT 기반 인증 시스템 구현 및 회원가입/로그인 API 추가                                                                                                                                                                             
  - auth / user 도메인을 관심사에 따라 분리하여 패키지 구조 정립

 ## 주요 변경사항

### 1. User 도메인
- User 엔티티 설계 (email, password, name, roles, level, tagIds)

### 2. Auth 도메인 (회원가입 / 로그인)
**[API]**
  - `POST /auth/register` — 회원가입 (201 Created, body 없음)
  - `POST /auth/login` — 로그인 (200 OK, ApiResponse<TokenResponse>)

**[Application]**
  - `AuthService` — 이메일 중복 검증, BCrypt 해싱, JWT 발급
  - `AuthErrorCode` — AUTH-001 ~ AUTH-005 (이메일 형식, 중복, 로그인 실패, 토큰 유효성, 토큰 만료)
  - Request DTO에 validation 적용 (`@Email, @NotBlank, @Pattern`)
    - 비밀번호: 영어 대/소문자, 숫자, 특수문자 각 1개 이상, 8~20자

### 3. JWT 인증 필터
- `JwtTokenProvider` — 토큰 생성 / 파싱, 실패 시 DomainException 발생 (EXPIRED_TOKEN, INVALID_TOKEN)
- `JwtAuthenticationFilter` — 토큰 파싱 실패 시 request attribute에 에러코드 저장
- `JwtAuthenticationEntryPoint` — 인증 실패 시 ApiResponse JSON 형태로 에러 응답 반환
- `SecurityConfig` — `/auth/register, /auth/login` permitAll, EntryPoint 등록

