### PR TITLE
JWT 토큰 관리 방식 변경 및 로그아웃 기능 구현

### DIFF
--- a/https/auth-api.http
+++ b/https/auth-api.http
@@ -37,7 +37,7 @@ Content-Type: application/json
   "level": "JUNIOR"
 }
 
-### 로그인
+### 로그인 - 응답 Set-Cookie 헤더에 accessToken 포함
 POST http://localhost:8080/auth/login
 Content-Type: application/json
 
@@ -58,6 +58,5 @@ Content-Type: application/json
 ### 인증 필요 API - 토큰 없이 (401)
 GET http://localhost:8080/users/me
 
-### 인증 필요 API - 유효하지 않은 토큰 (401)
-GET http://localhost:8080/users/me
-Authorization: Bearer invalid.token.here
+### 로그아웃 - 쿠키 삭제
+POST http://localhost:8080/auth/logout

--- a/src/main/java/com/lxpbe/auth/application/service/AuthService.java
+++ b/src/main/java/com/lxpbe/auth/application/service/AuthService.java
@@ -3,7 +3,6 @@ package com.lxpbe.auth.application.service;
 import com.lxpbe.auth.application.dto.LoginDto;
 import com.lxpbe.auth.application.dto.RegisterDto;
 import com.lxpbe.auth.domain.exception.AuthErrorCode;
-import com.lxpbe.auth.presentation.response.TokenResponse;
 import com.lxpbe.common.exception.DomainException;
 import com.lxpbe.common.security.JwtTokenProvider;
 import com.lxpbe.user.domain.User;
@@ -37,8 +36,8 @@ public class AuthService {
         userRepository.save(user);
     }
 
-    @Transactional
-    public TokenResponse login(LoginDto dto) {
+    @Transactional(readOnly = true)
+    public String login(LoginDto dto) {
         User user = userRepository.findByEmail(dto.email())
                 .orElseThrow(() -> new DomainException(AuthErrorCode.LOGIN_FAILED));
 
@@ -46,8 +45,7 @@ public class AuthService {
             throw new DomainException(AuthErrorCode.LOGIN_FAILED);
         }
 
-        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getRoles());
-        return new TokenResponse(accessToken);
+        return jwtTokenProvider.generateAccessToken(user.getId(), user.getRoles());
     }
 
     private void validateDuplicateEmail(String email) {

--- a/src/main/java/com/lxpbe/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/lxpbe/auth/presentation/controller/AuthController.java
@@ -5,10 +5,10 @@ import com.lxpbe.auth.application.dto.RegisterDto;
 import com.lxpbe.auth.application.service.AuthService;
 import com.lxpbe.auth.presentation.request.LoginRequest;
 import com.lxpbe.auth.presentation.request.RegisterRequest;
-import com.lxpbe.auth.presentation.response.TokenResponse;
-import com.lxpbe.common.response.ApiResponse;
+import com.lxpbe.common.security.CookieProvider;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
+    private final CookieProvider cookieProvider;
 
     @PostMapping("/register")
     public ResponseEntity<Void> register(@Valid @RequestBody RegisterRequest request) {
@@ -29,8 +30,23 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<ApiResponse<TokenResponse>> login(@Valid @RequestBody LoginRequest request) {
-        TokenResponse tokenResponse = authService.login(LoginDto.from(request));
-        return ResponseEntity.ok(new ApiResponse<>(tokenResponse, null));
+    public ResponseEntity<Void> login(@Valid @RequestBody LoginRequest request) {
+        String accessToken = authService.login(LoginDto.from(request));
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.SET_COOKIE,
+                        cookieProvider.createAccessTokenCookie(accessToken).toString()
+                )
+                .build();
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout() {
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.SET_COOKIE,
+                        cookieProvider.deleteAccessTokenCookie().toString()
+                )
+                .build();
     }
 }

--- a/src/main/java/com/lxpbe/auth/presentation/response/TokenResponse.java
+++ b/src/main/java/com/lxpbe/auth/presentation/response/TokenResponse.java
@@ -1,6 +1,0 @@
-package com.lxpbe.auth.presentation.response;
-
-public record TokenResponse(
-        String accessToken
-) {
-}

--- a/src/main/java/com/lxpbe/common/security/CookieProvider.java
+++ b/src/main/java/com/lxpbe/common/security/CookieProvider.java
@@ -1,0 +1,35 @@
+package com.lxpbe.common.security;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieProvider {
+    private static final String ACCESS_TOKEN_COOKIE = "accessToken";
+
+    private final long accessTokenExpiration;
+
+    public CookieProvider(JwtProperties jwtProperties) {
+        this.accessTokenExpiration = jwtProperties.accessTokenExpiration();
+    }
+
+    public ResponseCookie createAccessTokenCookie(String token) {
+        return ResponseCookie.from(ACCESS_TOKEN_COOKIE, token)
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(accessTokenExpiration / 1000)
+                .build();
+    }
+
+    public ResponseCookie deleteAccessTokenCookie() {
+        return ResponseCookie.from(ACCESS_TOKEN_COOKIE, "")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(0)
+                .build();
+    }
+}

--- a/src/main/java/com/lxpbe/common/security/CookieProvider.java
+++ b/src/main/java/com/lxpbe/common/security/CookieProvider.java
@@ -16,7 +16,7 @@ public class CookieProvider {
     public ResponseCookie createAccessTokenCookie(String token) {
         return ResponseCookie.from(ACCESS_TOKEN_COOKIE, token)
                 .httpOnly(true)
-                .secure(true)
+                .secure(false)
                 .sameSite("Lax")
                 .path("/")
                 .maxAge(accessTokenExpiration / 1000)
@@ -26,7 +26,7 @@ public class CookieProvider {
     public ResponseCookie deleteAccessTokenCookie() {
         return ResponseCookie.from(ACCESS_TOKEN_COOKIE, "")
                 .httpOnly(true)
-                .secure(true)
+                .secure(false)
                 .sameSite("Lax")
                 .path("/")
                 .maxAge(0)

--- a/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
@@ -4,6 +4,7 @@ import com.lxpbe.common.exception.DomainException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.NonNull;
@@ -14,13 +15,13 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
     public static final String AUTH_ERROR_ATTRIBUTE = "AUTH_ERROR";
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
+    private static final String ACCESS_TOKEN_COOKIE = "accessToken";
     private static final String ROLE_PREFIX = "ROLE_";
 
     private final JwtTokenProvider jwtTokenProvider;
@@ -53,10 +54,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String extractToken(HttpServletRequest request) {
-        String header = request.getHeader(AUTHORIZATION_HEADER);
-        if (header != null && header.startsWith(BEARER_PREFIX)) {
-            return header.substring(BEARER_PREFIX.length());
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return null;
         }
-        return null;
+        return Arrays.stream(cookies)
+                .filter(cookie -> ACCESS_TOKEN_COOKIE.equals(cookie.getName()))
+                .findFirst()
+                .map(Cookie::getValue)
+                .orElse(null);
     }
 }


### PR DESCRIPTION
## 변경 사항
기존 body로 token을 반환해줬는데 아래와 같은 이유로 Cookie 방식으로 변경하게 되었습니다.

- 클라이언트가 토큰을 직접 저장 (localStorage, sessionStorage 등)
- 매 요청마다 Authorization: Bearer {token} 헤더를 직접 세팅해야 함
- XSS에 취약 - JS로 저장소 접근 가능

## 추가 기능
- Cookie 방식으로 변경하면서 `/logout` api도 함께 구현하였습니다.