### PR TITLE
토큰 없을 시 INVALID_TOKEN -> UNAUTHORIZED

### DIFF
--- a/src/main/java/com/lxpbe/common/security/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/lxpbe/common/security/JwtAuthenticationEntryPoint.java
@@ -27,7 +27,7 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
         ErrorCode errorCode = (ErrorCode) request.getAttribute(JwtAuthenticationFilter.AUTH_ERROR_ATTRIBUTE);
 
         if (errorCode == null) {
-            errorCode = AuthErrorCode.INVALID_TOKEN;
+            errorCode = AuthErrorCode.UNAUTHORIZED;
         }
 
         response.setStatus(errorCode.httpStatus().value());


### PR DESCRIPTION
기존에는 "유효하지 않은 토큰" - INVALID_TOKEN을 사용하였으나,
아예 토큰이 존재하지 않는 유저일 경우에는 "로그인이 필요하다" - UNAUTHORIZED 예외가 더 적절할 것이라고 판단하였습니다. 