### PR TITLE
추천 모듈을 위한 강좌 정보 조회 facade 구현

### DIFF
--- a/src/main/java/com/lxpbe/course/application/result/CourseResult.java
+++ b/src/main/java/com/lxpbe/course/application/result/CourseResult.java
@@ -1,0 +1,22 @@
+package com.lxpbe.course.application.result;
+
+import com.lxpbe.course.domain.Course;
+import com.lxpbe.course.domain.enums.Level;
+
+import java.util.List;
+
+public record CourseResult(
+        Long courseId,
+        String title,
+        Level difficulty,
+        List<Long> tags
+) {
+    public static CourseResult from(Course course) {
+        return new CourseResult(
+                course.getId(),
+                course.getTitle(),
+                course.getDifficulty(),
+                course.getTags()
+        );
+    }
+}

--- a/src/main/java/com/lxpbe/course/application/service/CourseQueryService.java
+++ b/src/main/java/com/lxpbe/course/application/service/CourseQueryService.java
@@ -1,0 +1,28 @@
+package com.lxpbe.course.application.service;
+
+import com.lxpbe.course.application.result.CourseResult;
+import com.lxpbe.course.infrastructure.repository.CourseJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class CourseQueryService {
+    private final CourseJpaRepository courseJpaRepository;
+
+    public List<CourseResult> findAllPublicCourses() {
+        return courseJpaRepository.findAll().stream()
+                .map(CourseResult::from)
+                .toList();
+    }
+
+    public List<CourseResult> findById(List<Long> courseIds) {
+        return courseJpaRepository.findAllById(courseIds).stream()
+                .map(CourseResult::from)
+                .toList();
+    }
+}

--- a/src/main/java/com/lxpbe/course/infrastructure/facade/CourseFacade.java
+++ b/src/main/java/com/lxpbe/course/infrastructure/facade/CourseFacade.java
@@ -1,0 +1,34 @@
+package com.lxpbe.course.infrastructure.facade;
+
+import com.lxpbe.course.application.result.CourseResult;
+import com.lxpbe.course.application.service.CourseQueryService;
+import com.lxpbe.course.infrastructure.facade.dto.CourseMetadataDto;
+import com.lxpbe.tag.application.TagQueryService;
+import com.lxpbe.tag.application.result.TagResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CourseFacade {
+    private final CourseQueryService courseQueryService;
+    private final TagQueryService tagQueryService;
+
+    public List<CourseMetadataDto> findAllPublicCourses() {
+        List<CourseResult> courses = courseQueryService.findAllPublicCourses();
+        return courses.stream().map(course -> {
+          List<TagResult> tags = tagQueryService.findByIds(course.tags());
+          return CourseMetadataDto.from(course, tags);
+        }).toList();
+    }
+
+    public List<CourseMetadataDto> findByIds(List<Long> courseIds) {
+        List<CourseResult> courses = courseQueryService.findById(courseIds);
+        return courses.stream().map(course -> {
+            List<TagResult> tags = tagQueryService.findByIds(course.tags());
+            return CourseMetadataDto.from(course, tags);
+        }).toList();
+    }
+}

--- a/src/main/java/com/lxpbe/course/infrastructure/facade/dto/CourseMetadataDto.java
+++ b/src/main/java/com/lxpbe/course/infrastructure/facade/dto/CourseMetadataDto.java
@@ -1,0 +1,34 @@
+package com.lxpbe.course.infrastructure.facade.dto;
+
+import com.lxpbe.course.application.result.CourseResult;
+import com.lxpbe.tag.application.result.TagResult;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record CourseMetadataDto(
+        Long courseId,
+        String title,
+        Set<String> tags,
+        String difficulty,
+        boolean isPublic
+) {
+    public CourseMetadataDto {
+        Objects.requireNonNull(courseId, "courseId는 null일 수 없습니다.");
+        Objects.requireNonNull(title, "title은 null이거나 빈 문자열일 수 없습니다.");
+        Objects.requireNonNull(tags, "tags는 null 일 수 없습니다");
+        Objects.requireNonNull(difficulty, "difficulty는 null이거나 빈 문자열일 수 없습니다");
+    }
+
+    public static CourseMetadataDto from(CourseResult courseResult, List<TagResult> tagResults) {
+        return new CourseMetadataDto(
+                courseResult.courseId(),
+                courseResult.title(),
+                tagResults.stream().map(TagResult::name).collect(Collectors.toSet()),
+                courseResult.difficulty().name(),
+                true
+        );
+    }
+}


### PR DESCRIPTION
# 구현 내용
- CourseFacade 구현
- Course 조회를 위한 Query Service 구현
- CourseMetadataDto 추가

# To reviewer
- 추천 로직 관련 pr 에서도 한 번 언급 드렸었는데 Course의 모든 데이터를 가지고 오는 findAll()이 의도하신 바가 맞는지 궁금합니다. 우선 요청 주신대로 구현했지만 나중에 수 많은 강좌가 등록되었을 경우 한 번에 많은 데이터를 조회하게 됩니다. 
- isPublic에 대해 전달 들은 바가 없어서 프론트에 문의했는데 관련 정책을 잘 모르겠다고 하십니다 우선 true로 반환하게 작업했는데 상태값이 필요한 경우 재작업 요청 주세요     