### PR TITLE
유저 역할 변경 API

### DIFF
--- a/src/main/java/com/lxpbe/auth/application/service/AuthService.java
+++ b/src/main/java/com/lxpbe/auth/application/service/AuthService.java
@@ -45,7 +45,7 @@ public class AuthService {
             throw new AuthException(AuthErrorCode.LOGIN_FAILED);
         }
 
-        return jwtTokenProvider.generateAccessToken(user.getId(), user.getRoles());
+        return jwtTokenProvider.generateAccessToken(user.getId(), user.getRole());
     }
 
     private void validateDuplicateEmail(String email) {

--- a/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/lxpbe/common/security/JwtAuthenticationFilter.java
@@ -37,10 +37,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 Claims claims = jwtTokenProvider.getClaimsFromToken(token);
                 Long userId = Long.valueOf(claims.getSubject());
 
-                List<String> roles = claims.get("roles", List.class);
-                List<SimpleGrantedAuthority> authorities = roles.stream()
-                        .map(role -> new SimpleGrantedAuthority(ROLE_PREFIX + role))
-                        .toList();
+                String role = claims.get("role", String.class);
+                List<SimpleGrantedAuthority> authorities = List.of(
+                        new SimpleGrantedAuthority(ROLE_PREFIX + role));
 
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(userId, null, authorities);

--- a/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
+++ b/src/main/java/com/lxpbe/common/security/JwtTokenProvider.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
-import java.util.Set;
 
 @Component
 public class JwtTokenProvider {
@@ -28,13 +27,13 @@ public class JwtTokenProvider {
         this.accessTokenExpiration = jwtProperties.accessTokenExpiration();
     }
 
-    public String generateAccessToken(Long userId, Set<Role> roles) {
+    public String generateAccessToken(Long userId, Role role) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + accessTokenExpiration);
 
         return Jwts.builder()
                 .subject(String.valueOf(userId))
-                .claim("roles", roles.stream().map(Enum::name).toList())
+                .claim("role", role.name())
                 .issuedAt(now)
                 .expiration(expiry)
                 .signWith(secretKey)

--- a/src/main/java/com/lxpbe/course/application/service/CourseService.java
+++ b/src/main/java/com/lxpbe/course/application/service/CourseService.java
@@ -52,7 +52,7 @@ public class CourseService {
 
     @Transactional
     public CourseDetailResponse createCourse(Long instructorId, CourseCreateCommand command) {
-        User user = userRepository.findByIdAndRolesContaining(instructorId, Role.INSTRUCTOR)
+        User user = userRepository.findByIdAndRole(instructorId, Role.INSTRUCTOR)
                 .orElseThrow(() -> new CourseException(CourseErrorCode.INVALID_INSTRUCTOR));
 
         Course course =  Course.create(instructorId, command);
@@ -87,7 +87,7 @@ public class CourseService {
     }
 
     public InstructorResponse getInstructor(Long id) {
-        return userRepository.findByIdAndRolesContaining(id, Role.INSTRUCTOR)
+        return userRepository.findByIdAndRole(id, Role.INSTRUCTOR)
                 .map(user -> new InstructorResponse(user.getId(), user.getName()))
                 .orElse(InstructorResponse.unknown(id));
 

--- a/src/main/java/com/lxpbe/user/application/result/UserInfoResult.java
+++ b/src/main/java/com/lxpbe/user/application/result/UserInfoResult.java
@@ -8,7 +8,7 @@ public record UserInfoResult(
         Long userId,
         String email,
         String name,
-        List<String> roles,
+        String role,
         List<TagInfo> tags,
         String level
 ) {
@@ -25,7 +25,7 @@ public record UserInfoResult(
                 user.getId(),
                 user.getEmail(),
                 user.getName(),
-                user.getRoles().stream().map(Enum::name).toList(),
+                user.getRole().name(),
                 tagInfos,
                 user.getLevel().name()
         );

--- a/src/main/java/com/lxpbe/user/application/service/UserCommandService.java
+++ b/src/main/java/com/lxpbe/user/application/service/UserCommandService.java
@@ -1,5 +1,6 @@
 package com.lxpbe.user.application.service;
 
+import com.lxpbe.common.security.JwtTokenProvider;
 import com.lxpbe.tag.domain.Tag;
 import com.lxpbe.tag.repository.TagRepository;
 import com.lxpbe.user.application.result.UserInfoResult;
@@ -19,12 +20,23 @@ import org.springframework.stereotype.Service;
 public class UserCommandService {
     private final UserRepository userRepository;
     private final TagRepository tagRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public UserInfoResult updateMyInfo(Long userId, String name, List<Long> tagIds, Level level) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
+        User user = getUser(userId);
         user.updateInfo(name, level, tagIds);
         List<Tag> tags = tagRepository.findAllByIdIn(user.getTagIds());
         return UserInfoResult.from(user, tags);
+    }
+
+    public String updateRole(Long userId) {
+        User user = getUser(userId);
+        user.updateRole();
+        return jwtTokenProvider.generateAccessToken(user.getId(), user.getRole());
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(UserErrorCode.USER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/lxpbe/user/domain/User.java
+++ b/src/main/java/com/lxpbe/user/domain/User.java
@@ -9,7 +9,6 @@ import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -18,9 +17,7 @@ import jakarta.persistence.Table;
 import com.lxpbe.user.domain.enums.Level;
 import com.lxpbe.user.domain.enums.Role;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -54,11 +51,9 @@ public class User extends BaseEntity {
     private String name;
 
     @Getter
-    @Column(name = "role")
     @Enumerated(EnumType.STRING)
-    @ElementCollection(fetch = FetchType.EAGER)
-    @CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
-    private Set<Role> roles = EnumSet.noneOf(Role.class);
+    @Column(nullable = false)
+    private Role role;
 
     @Getter
     @Enumerated(EnumType.STRING)
@@ -72,11 +67,11 @@ public class User extends BaseEntity {
 
     @Builder
     private User(String email, String password, String name,
-                 Set<Role> roles, Level level, List<Long> tagIds) {
+                 Role role, Level level, List<Long> tagIds) {
         this.email = email;
         this.password = password;
         this.name = name;
-        this.roles = roles != null ? roles : EnumSet.noneOf(Role.class);
+        this.role = role;
         this.level = level;
         this.tagIds = tagIds != null ? tagIds : new ArrayList<>();
     }
@@ -89,7 +84,7 @@ public class User extends BaseEntity {
                 .email(email)
                 .password(encodedPassword)
                 .name(name)
-                .roles(EnumSet.of(role))
+                .role(role)
                 .level(level)
                 .tagIds(tagIds)
                 .build();

--- a/src/main/java/com/lxpbe/user/domain/User.java
+++ b/src/main/java/com/lxpbe/user/domain/User.java
@@ -102,6 +102,13 @@ public class User extends BaseEntity {
         }
     }
 
+    public void updateRole() {
+        if (this.role != Role.LEARNER) {
+            throw new UserException(UserErrorCode.ALREADY_INSTRUCTOR);
+        }
+        this.role = Role.INSTRUCTOR;
+    }
+
     public void updateInfo(String name, Level level, List<Long> tagIds) {
         if (tagIds != null) {
             validateCountTagIds(tagIds);

--- a/src/main/java/com/lxpbe/user/domain/exception/UserErrorCode.java
+++ b/src/main/java/com/lxpbe/user/domain/exception/UserErrorCode.java
@@ -11,6 +11,7 @@ public enum UserErrorCode implements ErrorCode {
     INVALID_EMAIL_FORMAT(HttpStatus.BAD_REQUEST, "USR_002", "이메일 형식이 올바르지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USR_003", "사용자를 찾을 수 없습니다."),
     INVALID_TAG_COUNT(HttpStatus.BAD_REQUEST, "USR_004", "태그는 최소 3개, 최대 5개여야 합니다."),
+    ALREADY_INSTRUCTOR(HttpStatus.BAD_REQUEST, "USR_005", "이미 강사입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/lxpbe/user/infrastructure/repository/UserRepository.java
+++ b/src/main/java/com/lxpbe/user/infrastructure/repository/UserRepository.java
@@ -10,5 +10,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
     boolean existsByEmail(String email);
 
-    Optional<User> findByIdAndRolesContaining(Long id, Role role);
+    Optional<User> findByIdAndRole(Long id, Role role);
 }

--- a/src/main/java/com/lxpbe/user/presentation/controller/UserApi.java
+++ b/src/main/java/com/lxpbe/user/presentation/controller/UserApi.java
@@ -32,4 +32,11 @@ public interface UserApi {
                             examples = @ExampleObject(value = UserApiResponseExamples.UPDATE_400)))
     })
     ResponseEntity<ApiResponse<UserInfoResponse>> updateMyInfo(Long userId, UpdateUserInfoRequest request);
+
+    @Operation(summary = "강사로 역할 변경", description = "LEARNER → INSTRUCTOR 역할 변경. 새로운 JWT 토큰이 쿠키에 설정됩니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "승격 성공 (Set-Cookie 헤더에 새 JWT 토큰 포함)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "이미 강사 역할")
+    })
+    ResponseEntity<Void> updateUserRole(Long userId);
 }

--- a/src/main/java/com/lxpbe/user/presentation/controller/UserController.java
+++ b/src/main/java/com/lxpbe/user/presentation/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.lxpbe.user.presentation.controller;
 
 import com.lxpbe.common.response.ApiResponse;
+import com.lxpbe.common.security.CookieProvider;
 import com.lxpbe.common.security.LoginUser;
 import com.lxpbe.user.application.result.UserInfoResult;
 import com.lxpbe.user.application.service.UserCommandService;
@@ -8,9 +9,11 @@ import com.lxpbe.user.application.service.UserQueryService;
 import com.lxpbe.user.presentation.request.UpdateUserInfoRequest;
 import com.lxpbe.user.presentation.response.UserInfoResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,12 +24,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController implements UserApi {
     private final UserQueryService userQueryService;
     private final UserCommandService userCommandService;
+    private final CookieProvider cookieProvider;
 
     @GetMapping("/me")
     public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(@LoginUser Long userId) {
         UserInfoResult result = userQueryService.getMyInfo(userId);
         UserInfoResponse response = UserInfoResponse.from(result);
         return ResponseEntity.ok(new ApiResponse<>(response, null));
+    }
+
+    @PostMapping("/role")
+    public ResponseEntity<Void> updateUserRole(@LoginUser Long userId) {
+        String accessToken = userCommandService.updateRole(userId);
+        return ResponseEntity.ok()
+                .header(
+                        HttpHeaders.SET_COOKIE,
+                        cookieProvider.createAccessTokenCookie(accessToken).toString()
+                )
+                .build();
     }
 
     @PatchMapping("/me")

--- a/src/main/java/com/lxpbe/user/presentation/docs/UserApiResponseExamples.java
+++ b/src/main/java/com/lxpbe/user/presentation/docs/UserApiResponseExamples.java
@@ -11,7 +11,7 @@ public final class UserApiResponseExamples {
                     "userId": 1,
                     "email": "user@example.com",
                     "name": "홍길동",
-                    "roles": ["LEARNER"],
+                    "role": "LEARNER",
                     "tags": [
                         { "id": 1, "content": "LLM" },
                         { "id": 2, "content": "ChatGPT" },

--- a/src/main/java/com/lxpbe/user/presentation/response/UserInfoResponse.java
+++ b/src/main/java/com/lxpbe/user/presentation/response/UserInfoResponse.java
@@ -2,13 +2,14 @@ package com.lxpbe.user.presentation.response;
 
 import com.lxpbe.user.application.result.UserInfoResult;
 import com.lxpbe.user.application.result.UserInfoResult.TagInfo;
+
 import java.util.List;
 
 public record UserInfoResponse(
         Long userId,
         String email,
         String name,
-        List<String> roles,
+        String role,
         List<TagInfo> tags,
         String level
 ) {
@@ -18,7 +19,7 @@ public record UserInfoResponse(
                 result.userId(),
                 result.email(),
                 result.name(),
-                result.roles(),
+                result.role(),
                 result.tags(),
                 result.level()
         );


### PR DESCRIPTION
### 기존 설계: 다중 역할 (Set<Role> + user_roles 테이블)

User가 여러 역할을 동시에 가질 수 있는 조합 모델.

예: LEARNER + INSTRUCTOR, ADMIN + CS_MANAGER

장점: 확장성, 조직 모델에 유연, 권한 조합 가능
단점: 복잡도 증가, 중복 권한 관리 필요

### 고민 .. : 단일 역할로 변경?

다중 역할이 필요한 구체적 비즈니스 케이스가 없음.

- "강사가 수강도 한다" → INSTRUCTOR 역할 자체에 수강 권한을 포함하면 됨 (별도 LEARNER 조합 불필요)
- 역할 간 권한이 포함관계(ADMIN > INSTRUCTOR > LEARNER)로 표현 가능
- CS_MANAGER는 고객응대 담당자로, 학습 계층과는 별개 축이지만 "강사이면서 CS 담당"인 케이스가 없으므로 단일 역할로 충분

### 결정

- `Set<Role> roles` + `user_roles` 테이블 → `Role role` 단일 컬럼으로 변경
- 역할: LEARNER, INSTRUCTOR, ADMIN, CS_MANAGER (한 유저는 하나만 가짐)
- 상위 역할이 하위 권한을 포함하는 구조